### PR TITLE
feat : 다이어리 목록 조회에서 팔로잉, 팔로워, 다이어리 작성 수 제거

### DIFF
--- a/server/forcutbook/src/main/java/konkuk/forcutbook/diary/DiaryService.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/diary/DiaryService.java
@@ -106,7 +106,9 @@ public class DiaryService {
     }
 
     public DiaryDetailResDto getDiary(Long userId, Long diaryId){
+        checkDiaryAuthority(userId, diaryId);
         Diary diary = findDiaryWithDiaryImage(diaryId);
+
         return DiaryDetailResDto.toDto(diary);
     }
 

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/diary/DiaryService.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/diary/DiaryService.java
@@ -101,18 +101,8 @@ public class DiaryService {
 
         //서비스 로직
         List<DiaryListEachResDto> diaryDtoList = diaryRepository.findDiaryListDtoByWriterId(userId);
-        Long diaryCount = diaryRepository.countByWriterIdAndStatus(userId, Status.ACTIVE);
-        Long following = friendRepository.countBySenderIdAndIsAccept(userId, true);
-        Long follower = friendRepository.countByReceiverIdAndIsAccept(userId, true);
 
-        return DiaryListResDto.builder()
-                .userId(userId)
-                .username(user.getUserName())
-                .follower(follower)
-                .following(following)
-                .diaryCount(diaryCount)
-                .diaries(diaryDtoList)
-                .build();
+        return new DiaryListResDto(userId, diaryDtoList);
     }
 
     public DiaryDetailResDto getDiary(Long userId, Long diaryId){
@@ -128,18 +118,8 @@ public class DiaryService {
 
         //서비스 로직
         List<DiaryListEachResDto> diaryDtoList = diaryRepository.findDiaryListDtoByWriterId(friendId);
-        Long diaryCount = diaryRepository.countByWriterIdAndStatus(friendId, Status.ACTIVE);
-        Long following = friendRepository.countBySenderIdAndIsAccept(friendId, true);
-        Long follower = friendRepository.countByReceiverIdAndIsAccept(friendId, true);
 
-        return DiaryListResDto.builder()
-                .userId(friendId)
-                .username(friend.getUserName())
-                .follower(follower)
-                .following(following)
-                .diaryCount(diaryCount)
-                .diaries(diaryDtoList)
-                .build();
+        return new DiaryListResDto(userId, diaryDtoList);
     }
 
     public DiaryFeedListResDto getDiaryFeed(Long userId){

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/diary/dto/DiaryDetailResDto.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/diary/dto/DiaryDetailResDto.java
@@ -18,7 +18,6 @@ public class DiaryDetailResDto {
     private List<DiaryImageResDto> images;
     private LocalDateTime createdAt;
 
-    //TODO 친구 이미지 등등 추가
     public static DiaryDetailResDto toDto(Diary diary) {
         return DiaryDetailResDto.builder()
                 .diaryId(diary.getId())

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/diary/dto/DiaryFeedResDto.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/diary/dto/DiaryFeedResDto.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public class DiaryFeedResDto {
     private Long userId;
     private String userName;
-//    private String userImage;
+    private String userImageUrl;
     private Long diaryId;
     private String title;
     private String content;
@@ -17,10 +17,10 @@ public class DiaryFeedResDto {
     private LocalDateTime createdAt;
 
     @QueryProjection
-    public DiaryFeedResDto(Long userId, String userName, Long diaryId, String title, String content, String imageUrl, LocalDateTime createdAt) {
+    public DiaryFeedResDto(Long userId, String userName, String userImageUrl, Long diaryId, String title, String content, String imageUrl, LocalDateTime createdAt) {
         this.userId = userId;
         this.userName = userName;
-//        this.userImage = userImage;
+        this.userImageUrl = userImageUrl;
         this.diaryId = diaryId;
         this.title = title;
         this.content = content;

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/diary/dto/DiaryListResDto.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/diary/dto/DiaryListResDto.java
@@ -2,6 +2,7 @@ package konkuk.forcutbook.diary.dto;
 
 import konkuk.forcutbook.diary.domain.Diary;
 import konkuk.forcutbook.domain.user.User;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,12 +10,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@Builder
+@AllArgsConstructor
 public class DiaryListResDto {
     private Long userId;
-    private String username;
-    private Long follower;
-    private Long following;
-    private Long diaryCount;
     private List<DiaryListEachResDto> diaries;
 }

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/diary/repository/DiaryRepositoryCustomImpl.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/diary/repository/DiaryRepositoryCustomImpl.java
@@ -49,6 +49,7 @@ public class DiaryRepositoryCustomImpl implements DiaryRepositoryCustom{
                 .select(Projections.constructor(DiaryFeedResDto.class,
                         user.id.as("userId"),
                         user.userName,
+                        user.imageUrl.as("userImageUrl"),
                         diary.id.as("diaryId"),
                         diary.title,
                         diary.content,


### PR DESCRIPTION
## 관련 이슈번호
 #36 
<br/>

## 작업 사항

- 다이어리 조회에 권한 검증 추가
- 다이어리 목록 조회에서 팔로잉, 팔로워, 다이어리 작성 수 제거
<br/>

## 기타 사항
<br/>
