### PR TITLE
feat : 팔로잉, 팔로워 기능 수정

### DIFF
--- a/server/forcutbook/src/main/java/konkuk/forcutbook/diary/dto/DiaryListEachResDto.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/diary/dto/DiaryListEachResDto.java
@@ -11,6 +11,9 @@ import java.time.LocalDateTime;
 @Builder(access = AccessLevel.PROTECTED)
 @Getter
 public class DiaryListEachResDto {
+    private Long userId;
+    private String userName;
+    private String userProfile;
     private Long diaryId;
     private String title;
     private String content;
@@ -18,22 +21,14 @@ public class DiaryListEachResDto {
     private LocalDateTime createdAt;
 
     @QueryProjection
-    public DiaryListEachResDto(Long diaryId, String title, String content, String imageUrl, LocalDateTime createdAt) {
+    public DiaryListEachResDto(Long userId, String userName, String userProfile, Long diaryId, String title, String content, String imageUrl, LocalDateTime createdAt) {
+        this.userId = userId;
+        this.userName = userName;
+        this.userProfile = userProfile;
         this.diaryId = diaryId;
         this.title = title;
         this.content = content;
         this.imageUrl = imageUrl;
         this.createdAt = createdAt;
-    }
-
-    public static DiaryListEachResDto toDto(Diary diary){
-//        String titleImgUrl = diary.getDiaryImages()
-        return DiaryListEachResDto.builder()
-                .diaryId(diary.getId())
-                .title(diary.getTitle())
-                .content(diary.getContent())
-//                .imageUrl()
-                .createdAt(diary.getCreatedAt())
-                .build();
     }
 }

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/diary/repository/DiaryRepositoryCustomImpl.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/diary/repository/DiaryRepositoryCustomImpl.java
@@ -29,6 +29,9 @@ public class DiaryRepositoryCustomImpl implements DiaryRepositoryCustom{
         QDiaryImage diaryImageSub = new QDiaryImage("diaryImageSub");
         return query
                 .select(Projections.constructor(DiaryListEachResDto.class,
+                        diary.writer.id.as("userId"),
+                        diary.writer.userName,
+                        diary.writer.imageUrl.as("userProfile"),
                         diary.id.as("diaryId"),
                         diary.title,
                         diary.content,

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendController.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendController.java
@@ -84,9 +84,9 @@ public class FriendController {
     @GetMapping("/{friendId}/follower")
     public ResponseEntity<BaseResponse> getFollowerList(@PathVariable Long userId,
                                                         @PathVariable Long friendId){
-        FriendListResDto resultDto = friendService.getFollowerList(userId);
+        FollowListResDto resultDto = friendService.getFollowerList(userId, friendId);
 
-        BaseResponse<FriendListResDto> response = new BaseResponse<>(resultDto);
+        BaseResponse<FollowListResDto> response = new BaseResponse<>(resultDto);
         return ResponseEntity.ok(response);
     }
 

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendController.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendController.java
@@ -1,5 +1,7 @@
 package konkuk.forcutbook.friend;
 
+import konkuk.forcutbook.friend.dto.FollowListResDto;
+import konkuk.forcutbook.friend.dto.FollowResDto;
 import konkuk.forcutbook.friend.dto.FriendListResDto;
 import konkuk.forcutbook.friend.dto.FriendStatus;
 import konkuk.forcutbook.global.response.BaseResponse;
@@ -79,8 +81,9 @@ public class FriendController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/follower")
-    public ResponseEntity<BaseResponse> getFollowerList(@PathVariable Long userId){
+    @GetMapping("/{friendId}/follower")
+    public ResponseEntity<BaseResponse> getFollowerList(@PathVariable Long userId,
+                                                        @PathVariable Long friendId){
         FriendListResDto resultDto = friendService.getFollowerList(userId);
 
         BaseResponse<FriendListResDto> response = new BaseResponse<>(resultDto);
@@ -88,10 +91,11 @@ public class FriendController {
     }
 
     @GetMapping("/following")
-    public ResponseEntity<BaseResponse> getFollowingList(@PathVariable Long userId){
-        FriendListResDto resultDto = friendService.getFollowingList(userId);
+    public ResponseEntity<BaseResponse> getFollowingList(@PathVariable Long userId,
+                                                         @PathVariable Long friendId){
+        FollowListResDto resultDto = friendService.getFollowingList(userId, friendId);
 
-        BaseResponse<FriendListResDto> response = new BaseResponse<>(resultDto);
+        BaseResponse<FollowListResDto> response = new BaseResponse<>(resultDto);
         return ResponseEntity.ok(response);
     }
 }

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendCustomRepository.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendCustomRepository.java
@@ -1,0 +1,9 @@
+package konkuk.forcutbook.friend;
+
+import konkuk.forcutbook.friend.dto.FollowResDto;
+
+import java.util.List;
+
+public interface FriendCustomRepository {
+    List<FollowResDto> findFollowingListDto(Long userId, Long friendId);
+}

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendCustomRepository.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendCustomRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface FriendCustomRepository {
     List<FollowResDto> findFollowingListDto(Long userId, Long friendId);
+    List<FollowResDto> findFollowerListDto(Long userId, Long friendId);
 }

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendRepository.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendRepository.java
@@ -7,9 +7,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface FriendRepository extends JpaRepository<Friend, Long> {
+public interface FriendRepository extends JpaRepository<Friend, Long>, FriendCustomRepository {
     boolean existsBySenderIdAndReceiverId(Long senderId, Long receiverId);
+
     boolean existsBySenderIdAndReceiverIdAndIsAccept(Long senderId, Long receiverId, boolean isAccept);
+
     Optional<Friend> findBySenderIdAndReceiverId(Long senderId, Long receiverId);
 
     @EntityGraph(attributePaths = {"sender"})
@@ -19,5 +21,6 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     List<Friend> findBySenderIdAndIsAccept(Long senderId, boolean isAccept);
 
     Long countBySenderIdAndIsAccept(Long senderId, boolean isAccept);
+
     Long countByReceiverIdAndIsAccept(Long receiverId, boolean isAccept);
 }

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendService.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendService.java
@@ -3,6 +3,8 @@ package konkuk.forcutbook.friend;
 import konkuk.forcutbook.domain.user.User;
 import konkuk.forcutbook.domain.user.UserRepository;
 import konkuk.forcutbook.friend.domain.Friend;
+import konkuk.forcutbook.friend.dto.FollowListResDto;
+import konkuk.forcutbook.friend.dto.FollowResDto;
 import konkuk.forcutbook.friend.dto.FriendListResDto;
 import konkuk.forcutbook.friend.exception.FriendException;
 import konkuk.forcutbook.friend.exception.errorcode.FriendExceptionErrorCode;
@@ -112,15 +114,16 @@ public class FriendService {
         return FriendListResDto.toDtoBySender(friends);
     }
 
-    public FriendListResDto getFollowingList(Long userId) {
+    public FollowListResDto getFollowingList(Long userId, Long friendId) {
         //검증 로직
         checkExistUser(userId);
 
         //서비스 로직
-        List<Friend> friends = friendRepository.findBySenderIdAndIsAccept(userId, true);
+        List<FollowResDto> followingListDto = friendRepository.findFollowingListDto(userId, friendId);
 
-        return FriendListResDto.toDtoByReceiver(friends);
+        return new FollowListResDto(userId, followingListDto);
     }
+
 
     private User findUser(Long userId){
         User user = userRepository.findById(userId).orElse(null);

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendService.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendService.java
@@ -106,7 +106,10 @@ public class FriendService {
 
     public FollowListResDto getFollowerList(Long userId, Long friendId) {
         //검증 로직
-        checkExistUser(userId);
+        checkExistUser(userId, friendId);
+        if (userId != friendId){
+            checkIsFriendShip(userId, friendId);
+        }
 
         //서비스 로직
         List<FollowResDto> followerListDto = friendRepository.findFollowerListDto(userId, friendId);
@@ -116,7 +119,10 @@ public class FriendService {
 
     public FollowListResDto getFollowingList(Long userId, Long friendId) {
         //검증 로직
-        checkExistUser(userId);
+        checkExistUser(userId, friendId);
+        if (userId != friendId){
+            checkIsFriendShip(userId, friendId);
+        }
 
         //서비스 로직
         List<FollowResDto> followingListDto = friendRepository.findFollowingListDto(userId, friendId);

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendService.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/friend/FriendService.java
@@ -104,14 +104,14 @@ public class FriendService {
         return FriendListResDto.toDtoBySender(acceptList);
     }
 
-    public FriendListResDto getFollowerList(Long userId) {
+    public FollowListResDto getFollowerList(Long userId, Long friendId) {
         //검증 로직
         checkExistUser(userId);
 
         //서비스 로직
-        List<Friend> friends = friendRepository.findByReceiverIdAndIsAccept(userId, true);
+        List<FollowResDto> followerListDto = friendRepository.findFollowerListDto(userId, friendId);
 
-        return FriendListResDto.toDtoBySender(friends);
+        return new FollowListResDto(userId, followerListDto);
     }
 
     public FollowListResDto getFollowingList(Long userId, Long friendId) {

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/friend/dto/FollowListResDto.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/friend/dto/FollowListResDto.java
@@ -1,0 +1,13 @@
+package konkuk.forcutbook.friend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class FollowListResDto {
+    private Long userId;
+    private List<FollowResDto> data;
+}

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/friend/dto/FollowResDto.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/friend/dto/FollowResDto.java
@@ -1,0 +1,25 @@
+package konkuk.forcutbook.friend.dto;
+
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class FollowResDto {
+    private Long userId;
+    private String userName;
+    private String imageUrl;
+    private FriendStatus status;
+    private LocalDateTime createdAt;
+
+    @QueryProjection
+    public FollowResDto(Long userId, String userName, String imageUrl, boolean isAccept, LocalDateTime createdAt) {
+        this.userId = userId;
+        this.userName = userName;
+        this.imageUrl = imageUrl;
+        this.status = isAccept ? FriendStatus.FOLLOWING : FriendStatus.UNFOLLOING;
+        this.createdAt = createdAt;
+    }
+}

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/friend/dto/FriendStatus.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/friend/dto/FriendStatus.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum FriendStatus {
-    DEFAULT("요청"), REQUEST("요청"), ACCEPT("수락"), DENY("거절"), CANCEL("취소");
+    DEFAULT("요청"), REQUEST("요청"), ACCEPT("수락"), DENY("거절"), CANCEL("취소"), FOLLOWING("구독중"), UNFOLLOING("구독");
 
     FriendStatus(String message) {
         this.message = message;

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/friend/exception/FriendCustomRepositoryImpl.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/friend/exception/FriendCustomRepositoryImpl.java
@@ -37,4 +37,24 @@ public class FriendCustomRepositoryImpl implements FriendCustomRepository {
                         friend.isAccept.isTrue())
                 .fetch();
     }
+
+    @Override
+    public List<FollowResDto> findFollowerListDto(Long userId, Long friendId) {
+        QFriend subFriend = new QFriend("subFriend");
+        return query
+                .select(Projections.constructor(FollowResDto.class,
+                        friend.sender.id.as("userId"),
+                        friend.sender.userName,
+                        friend.sender.imageUrl,
+                        subFriend.isAccept,
+                        friend.createdAt
+                ))
+                .from(friend)
+                .leftJoin(subFriend)
+                .on(friend.sender.id.eq(subFriend.receiver.id),
+                        subFriend.sender.id.eq(userId))
+                .where(friend.receiver.id.eq(friendId),
+                        friend.isAccept.isTrue())
+                .fetch();
+    }
 }

--- a/server/forcutbook/src/main/java/konkuk/forcutbook/friend/exception/FriendCustomRepositoryImpl.java
+++ b/server/forcutbook/src/main/java/konkuk/forcutbook/friend/exception/FriendCustomRepositoryImpl.java
@@ -1,0 +1,40 @@
+package konkuk.forcutbook.friend.exception;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import konkuk.forcutbook.friend.FriendCustomRepository;
+import konkuk.forcutbook.friend.domain.QFriend;
+import konkuk.forcutbook.friend.dto.FollowResDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+import static konkuk.forcutbook.friend.domain.QFriend.friend;
+
+@Slf4j
+@RequiredArgsConstructor
+public class FriendCustomRepositoryImpl implements FriendCustomRepository {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<FollowResDto> findFollowingListDto(Long userId, Long friendId) {
+        QFriend subFriend = new QFriend("subFriend");
+        return query
+                .select(Projections.constructor(FollowResDto.class,
+                        friend.receiver.id.as("userId"),
+                        friend.receiver.userName,
+                        friend.receiver.imageUrl,
+                        subFriend.isAccept,
+                        friend.createdAt
+                ))
+                .from(friend)
+                .leftJoin(subFriend)
+                .on(friend.receiver.id.eq(subFriend.receiver.id),
+                        subFriend.sender.id.eq(userId))
+                .where(friend.sender.id.eq(friendId),
+                        friend.isAccept.isTrue())
+                .fetch();
+    }
+}

--- a/server/forcutbook/src/test/java/konkuk/forcutbook/diary/DiaryServiceIntegrationTest.java
+++ b/server/forcutbook/src/test/java/konkuk/forcutbook/diary/DiaryServiceIntegrationTest.java
@@ -134,6 +134,9 @@ class DiaryServiceIntegrationTest {
         assertThat(results.getUserId()).isEqualTo(user1.getId());
 
         List<DiaryListEachResDto> diaries = results.getDiaries();
+        assertThat(diaries).extracting("userId").contains(user1.getId());
+        assertThat(diaries).extracting("userName").contains(user1.getUserName());
+        assertThat(diaries).extracting("userProfile").contains(user1.getImageUrl());
         assertThat(diaries.stream().map(DiaryListEachResDto::getDiaryId)).contains(diary1.getId(), diary2.getId());
         assertThat(diaries.stream().map(DiaryListEachResDto::getTitle)).contains(diary1.getTitle(), diary2.getTitle());
         assertThat(diaries.stream().map(DiaryListEachResDto::getContent)).contains(diary1.getContent(), diary2.getContent());

--- a/server/forcutbook/src/test/java/konkuk/forcutbook/friend/FriendServiceIntegrationTest.java
+++ b/server/forcutbook/src/test/java/konkuk/forcutbook/friend/FriendServiceIntegrationTest.java
@@ -233,35 +233,45 @@ class FriendServiceIntegrationTest {
     @DisplayName("팔로워 목록 조회")
     void getFollowerList() {
         //given
-        User sender1 = createUser("sender1");
-        User sender2 = createUser("sender2");
-        User waitSender = createUser("waitSender");
-        User receiver = createUser("receiver");
-        userRepository.save(sender1);
-        userRepository.save(sender2);
-        userRepository.save(waitSender);
-        userRepository.save(receiver);
+        User user = createUser("user");
+        User friend = createUser("friend");
+        User follower1 = createUser("follower1");
+        User follower2 = createUser("follower2");
+        em.persist(user);
+        em.persist(friend);
+        em.persist(follower1);
+        em.persist(follower2);
 
-        Friend friend1 = Friend.createFriend(sender1, receiver);
-        friend1.setAccept(true);
-        friendRepository.save(friend1);
+        Friend friendShip1 = Friend.createFriend(user, friend);
+        friendShip1.setAccept(true);
+        em.persist(friendShip1);
 
-        Friend friend2 = Friend.createFriend(sender2, receiver);
-        friend2.setAccept(true);
-        friendRepository.save(friend2);
+        Friend friendShip2 = Friend.createFriend(follower1, friend);
+        friendShip2.setAccept(true);
+        em.persist(friendShip2);
 
-        Friend waitFriend = Friend.createFriend(waitSender, receiver);
-        friendRepository.save(waitFriend);
+        Friend friendShip3 = Friend.createFriend(follower2, friend);
+        friendShip3.setAccept(true);
+        em.persist(friendShip3);
+
+        Friend friendShip4 = Friend.createFriend(user, follower1);
+        friendShip4.setAccept(true);
+        em.persist(friendShip4);
+
+        em.flush();
+        em.clear();
 
         //when
-        FriendListResDto dto = friendService.getFollowerList(receiver.getId());
+        FollowListResDto result = friendService.getFollowerList(user.getId(), friend.getId());
 
         //then
-        List<FriendResDto> data = dto.getData();
-        assertThat(data.size()).isEqualTo(2);
-        assertThat(data).extracting("userId").contains(sender1.getId(), sender2.getId());
-        assertThat(data).extracting("userName").contains(sender1.getUserName(), sender2.getUserName());
-//        assertThat(data).extracting("createdAt").contains(friend1.getCreatedAt(), friend2.getCreatedAt());
+        assertThat(result.getUserId()).isEqualTo(user.getId());
+
+        List<FollowResDto> data = result.getData();
+        assertThat(data).extracting("userId").contains(follower1.getId(), follower2.getId());
+        assertThat(data).extracting("userName").contains(follower1.getUserName(), follower2.getUserName());
+        assertThat(data).extracting("imageUrl").contains(follower1.getImageUrl(), follower2.getImageUrl());
+        assertThat(data).extracting("status").contains(FriendStatus.FOLLOWING, FriendStatus.UNFOLLOING);
     }
 
     @Test

--- a/server/forcutbook/src/test/java/konkuk/forcutbook/friend/exception/FriendCustomRepositoryImplTest.java
+++ b/server/forcutbook/src/test/java/konkuk/forcutbook/friend/exception/FriendCustomRepositoryImplTest.java
@@ -1,0 +1,71 @@
+package konkuk.forcutbook.friend.exception;
+
+import jakarta.persistence.EntityManager;
+import konkuk.forcutbook.domain.user.User;
+import konkuk.forcutbook.friend.FriendRepository;
+import konkuk.forcutbook.friend.domain.Friend;
+import konkuk.forcutbook.friend.dto.FollowResDto;
+import konkuk.forcutbook.friend.dto.FriendStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+class FriendCustomRepositoryImplTest {
+
+    @Autowired
+    EntityManager em;
+    @Autowired
+    FriendRepository friendRepository;
+
+    @Test
+    void findFollowingListDto() {
+        User user = createUser("user");
+        User friend = createUser("friend");
+        User following1 = createUser("following1");
+        User following2 = createUser("following2");
+        em.persist(user);
+        em.persist(friend);
+        em.persist(following1);
+        em.persist(following2);
+
+        Friend friendShip1 = Friend.createFriend(user, friend);
+        friendShip1.setAccept(true);
+        em.persist(friendShip1);
+
+        Friend friendShip2 = Friend.createFriend(friend, following1);
+        friendShip2.setAccept(true);
+        em.persist(friendShip2);
+
+        Friend friendShip3 = Friend.createFriend(friend, following2);
+        friendShip3.setAccept(true);
+        em.persist(friendShip3);
+
+        Friend friendShip4 = Friend.createFriend(user, following1);
+        friendShip4.setAccept(true);
+        em.persist(friendShip4);
+
+        em.flush();
+        em.clear();
+
+        //when
+        List<FollowResDto> result = friendRepository.findFollowingListDto(user.getId(), friend.getId());
+        assertThat(result).extracting("userId").contains(following1.getId(), following2.getId());
+        assertThat(result).extracting("userName").contains(following1.getUserName(), following2.getUserName());
+        assertThat(result).extracting("imageUrl").contains(following1.getImageUrl(), following2.getImageUrl());
+        assertThat(result).extracting("status").contains(FriendStatus.FOLLOWING, FriendStatus.UNFOLLOING);
+    }
+
+    User createUser(String username){
+        User user = new User();
+        user.setUserName(username);
+        user.setPassword("test");
+        return user;
+    }
+}


### PR DESCRIPTION
## 관련 이슈번호
<br/>

## 작업 사항

- 팔로워 조회시 사용자와 팔로워 유저 사이의 관계 조회 필드 추가
- 팔로잉 조회시 사용자와 팔로워 유저 사이의 관계 조회 필드 추가
- 내 다이어리 목록 조회에서 작성자 아이디, 닉네임, 프로필 필드 추가

<br/>

## 기타 사항
<br/>
